### PR TITLE
Reduced time precision from nano seconds to miliseconds.

### DIFF
--- a/main.c
+++ b/main.c
@@ -804,7 +804,7 @@ int main(int argc, char* argv[])
 		}
 		PCAPOffset += PktHeader->LengthCapture; 
 
-		u64 PacketTS = (u64)PktHeader->Sec * 1000000000ULL + (u64)PktHeader->NSec * TScale;
+    u64 PacketTS = (u64)PktHeader->Sec * 1000ULL + (u64)PktHeader->NSec * TScale;
 
 
 		// output per packet JSON meta data


### PR DESCRIPTION
Due to limitations of Javascript time formats, please can we reduce the time precision of EpochTS in the JSON format from nanoseconds to miliseconds so that Grafana can ingest the data.