### PR TITLE
TopN sorting with exact byte match. Second sort based on packet prope…

### DIFF
--- a/flow.c
+++ b/flow.c
@@ -1389,10 +1389,9 @@ static int cmp_flowlist_light(const void* a, const void* b, void *arg)
 // sort the flow list, and output the top N by total bytes 
 static u32 FlowTopN(u32* SortList, FlowIndex_t* FlowIndex, u32 FlowMax, u8 *sMac, u8 *dMac)
 {
-	u64	j			= 0, last_data;
+	u64	j			= 0;
 	u64	MinByte		= (u64)-1;
 	u64	MaxByte 	= (u64)0;
-	int i, last_idx = 0;
 
 	// reset sorted output
 	u32 SortListPos = 0;
@@ -1434,7 +1433,9 @@ static u32 FlowTopN(u32* SortList, FlowIndex_t* FlowIndex, u32 FlowMax, u8 *sMac
 		SortListPos = min64(FlowMax, j);
 
 		// Need 2nd sort on the pkts having same TotalByte
-		last_data = FlowIndex->FlowList[0].TotalByte;
+		u64 last_data = FlowIndex->FlowList[0].TotalByte;
+		int	i;
+		int	last_idx;
 		for (i=1, last_idx=0; i < SortListPos; i++)
 		{
 			if (FlowIndex->FlowList[List[i*2 + 0]].TotalByte != last_data)

--- a/flow.c
+++ b/flow.c
@@ -1372,8 +1372,8 @@ static int cmp_flowlist_heavy(const void* a, const void* b, void *arg)
 	const u64* b64 = (const u64*)b;
 	FlowRecord_t *FlowList = (FlowRecord_t *)arg;
 
-	// compare L2, L3, L4 and other proto information to get detailed cmp
-	return memcmp(&FlowList[a64[1]], &FlowList[b64[1]], offsetof(FlowRecord_t, pad));
+	// compare based on SHA1, which is pre-calculated per pkt flow
+	return memcmp(FlowList[a64[1]].SHA1, &FlowList[b64[1]].SHA1, sizeof(FlowList[0].SHA1));
 }
 
 static int cmp_flowlist_light(const void* a, const void* b, void *arg)

--- a/flow.c
+++ b/flow.c
@@ -1407,6 +1407,7 @@ static u32 FlowTopN(u32* SortList, FlowIndex_t* FlowIndex, u32 FlowMax, u8 *sMac
 			{
 				List[i*2 + 0] = i;
 				List[i*2 + 1] = i;
+				j++;
 			}
 			else if (MAC_CMP(FlowIndex->FlowList[i].EtherDst, dMac) &&
 					MAC_CMP(FlowIndex->FlowList[i].EtherSrc, sMac))
@@ -1420,10 +1421,6 @@ static u32 FlowTopN(u32* SortList, FlowIndex_t* FlowIndex, u32 FlowMax, u8 *sMac
 			fprintf(stderr, "i: %d TotalByte: %llu SRC:" MAC_FMT " DEST: " MAC_FMT "\n", i, FlowIndex->FlowList[i].TotalByte,
 					MAC_PRNT_S(&FlowIndex->FlowList[i]), MAC_PRNT_D(&FlowIndex->FlowList[i]));
 #endif
-		}
-		if (!g_FlowTopNMac)
-		{
-			j = FlowIndex->FlowCntSnapshot;
 		}
 
 		// sort all flows by total bytes
@@ -1851,7 +1848,7 @@ void* Flow_Worker(void* User)
 
 	FlowIndex_t* FlowIndexLast = NULL;
 
-	u8	SortListCount = ((g_FlowTopNMac) ? g_FlowTopNMac : 1);
+	u8	SortListCount = ((g_FlowTopNMac) ? g_FlowTopNMac + 1 : 1);
 	u32	SortListCnt[SortListCount];
 	u32* SortList[SortListCount];
 
@@ -1951,7 +1948,8 @@ void* Flow_Worker(void* User)
 					// if top talkers is enabled, reduce the flow list
 					if (g_FlowTopNEnable)
 					{
-						for (int i=0; i < SortListCount; i++)
+						int	i = 0;
+						for (i=0; i < g_FlowTopNMac; i++)
 						{
 							if (g_FlowTopNMac)
 							{
@@ -1962,6 +1960,8 @@ void* Flow_Worker(void* User)
 								SortListCnt[i] = FlowTopN(SortList[i], FlowIndex, g_FlowTopNMax, NULL, NULL);
 							}
 						}
+						// we need default TopN in all the case
+						SortListCnt[i] = FlowTopN(SortList[i], FlowIndex, g_FlowTopNMax, NULL, NULL);
 					}
 					// use a linear map / no sorting 
 					else


### PR DESCRIPTION
Still "TCP.WindowMin/Max" are different and we can't disable threads in this case otherwise this issue itself won't happen.
So, to verify this, I have used "jq"...which will parse JSON and gives value for fields we select.

For example:
jq -c [.timestamp,.TotalPkt,.TotalByte,.MACSrc,.MACDst] json_file_name > <some_file>

Output:
[1559567701500,1090060,1497742440,"7c:e2:ca:bd:97:d9","00:0e:52:80:00:16"]
[1559567701500,43765,38828721,"7c:e2:ca:bd:97:d9","00:0e:52:80:00:16"]
[1559567701500,21042,30233021,"7c:e2:ca:bd:97:d9","00:0e:52:80:00:16"]
...